### PR TITLE
fix: make kms_key_crn null by default in solution

### DIFF
--- a/solutions/account-infrastructure-base/variables.tf
+++ b/solutions/account-infrastructure-base/variables.tf
@@ -27,7 +27,7 @@ variable "resource_tags" {
 
 variable "kms_key_crn" {
   type        = string
-  description = "CRN of the KMS key to encrypt the COS bucket."
+  description = "CRN of the KMS key to encrypt the COS bucket, required if 'var.provision_atracker_cos' is true."
   default     = null
 }
 

--- a/solutions/account-infrastructure-base/variables.tf
+++ b/solutions/account-infrastructure-base/variables.tf
@@ -44,6 +44,7 @@ variable "cos_bucket_management_endpoint_type" {
 variable "allowed_ip_addresses" {
   description = "List of the IP addresses and subnets from which IAM tokens can be created for the account."
   type        = list(string)
+  default     = null
 }
 
 variable "provision_atracker_cos" {

--- a/solutions/account-infrastructure-base/variables.tf
+++ b/solutions/account-infrastructure-base/variables.tf
@@ -28,6 +28,7 @@ variable "resource_tags" {
 variable "kms_key_crn" {
   type        = string
   description = "CRN of the KMS key to encrypt the COS bucket."
+  default     = null
 }
 
 variable "cos_bucket_management_endpoint_type" {


### PR DESCRIPTION
### Description
`kms_key_crn` was not marked as null by default in the solution so was required, as the observability portion is now optional this should be null and validation is done at the base level of the module to determine if it is needed.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

`var.kms_key_crn` and `var.allowed_ip_addresses` are no longer required variables in the solution

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
